### PR TITLE
feat: use `@copilot-extensions/preview-sdk` to call LLM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { Octokit } from "@octokit/core";
 import express from "express";
 import { Readable } from "node:stream";
+import { prompt } from '@copilot-extensions/preview-sdk';
 
 const app = express()
 
@@ -28,23 +29,13 @@ app.post("/", express.json(), async (req, res) => {
 
   // Use Copilot's LLM to generate a response to the user's messages, with
   // our extra system messages attached.
-  const copilotLLMResponse = await fetch(
-    "https://api.githubcopilot.com/chat/completions",
-    {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${tokenForUser}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        messages,
-        stream: true,
-      }),
-    }
-  );
+  const copilotLLMResponse = await prompt.stream({
+    token: tokenForUser,
+    messages
+  });
 
   // Stream the response straight back to the user.
-  Readable.from(copilotLLMResponse.body).pipe(res);
+  Readable.from(copilotLLMResponse.stream).pipe(res);
 })
 
 const port = Number(process.env.PORT || '3000')

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,18 @@
     "": {
       "name": "blackbeard-extension",
       "dependencies": {
+        "@copilot-extensions/preview-sdk": "^5.0.1",
         "@octokit/core": "^6.1.2",
         "express": "^4.19.2"
+      }
+    },
+    "node_modules/@copilot-extensions/preview-sdk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@copilot-extensions/preview-sdk/-/preview-sdk-5.0.1.tgz",
+      "integrity": "sha512-DvuJtTBl0aWvZnaNYVBiXuCdJN27ya6GYcJjv6J42Pnu1ubXHm8GHzUhIgLU/35c87HVHaITVah/jXogH3eChg==",
+      "dependencies": {
+        "@octokit/request": "^9.1.3",
+        "@octokit/request-error": "^6.1.4"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -67,9 +77,9 @@
       "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
     },
     "node_modules/@octokit/request": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
-      "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
       "dependencies": {
         "@octokit/endpoint": "^10.0.0",
         "@octokit/request-error": "^6.0.1",
@@ -81,9 +91,9 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-      "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
+      "integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
       "dependencies": {
         "@octokit/types": "^13.0.0"
       },
@@ -789,6 +799,15 @@
     }
   },
   "dependencies": {
+    "@copilot-extensions/preview-sdk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@copilot-extensions/preview-sdk/-/preview-sdk-5.0.1.tgz",
+      "integrity": "sha512-DvuJtTBl0aWvZnaNYVBiXuCdJN27ya6GYcJjv6J42Pnu1ubXHm8GHzUhIgLU/35c87HVHaITVah/jXogH3eChg==",
+      "requires": {
+        "@octokit/request": "^9.1.3",
+        "@octokit/request-error": "^6.1.4"
+      }
+    },
     "@octokit/auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
@@ -833,9 +852,9 @@
       "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
     },
     "@octokit/request": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
-      "integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
       "requires": {
         "@octokit/endpoint": "^10.0.0",
         "@octokit/request-error": "^6.0.1",
@@ -844,9 +863,9 @@
       }
     },
     "@octokit/request-error": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
-      "integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
+      "integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
       "requires": {
         "@octokit/types": "^13.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@copilot-extensions/preview-sdk": "^5.0.1",
     "@octokit/core": "^6.1.2",
     "express": "^4.19.2"
   }


### PR DESCRIPTION
Inspired by https://github.com/copilot-extensions/github-models-extension/pull/6

Feel free to disregard if the intention was to keep this example without the sdk to show underlying service API.